### PR TITLE
chore: update curve URLs

### DIFF
--- a/app/contexts/useCurve.tsx
+++ b/app/contexts/useCurve.tsx
@@ -35,7 +35,7 @@ export const CurveContextApp = ({children}: {children: React.ReactElement}): Rea
 	 **	Fetch all the CurveGauges to be able to create some new if required
 	 ***************************************************************************/
 	const {data: gaugesWrapper, isLoading: isLoadingGauges} = useFetch<TCurveAllGauges>({
-		endpoint: 'https://api.curve.fi/v1/getAllGauges',
+		endpoint: 'https://api.curve.finance/v1/getAllGauges',
 		schema: curveAllGaugesSchema
 	});
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -134,7 +134,7 @@ function Factory(): ReactElement {
 		const name = decodeAsString(results[0]);
 		const symbol = decodeAsString(results[1]);
 		set_gaugeDisplayData({
-			name: name.replace('Curve.fi', '').replace('Gauge Deposit', '') || selectedOption.value.name,
+			name: name.replace('Curve.finance', '').replace('Gauge Deposit', '') || selectedOption.value.name,
 			symbol: symbol.replace('-gauge', '').replace('-f', '') || selectedOption.value.name,
 			poolAddress: selectedOption.value.poolAddress,
 			gaugeAddress: selectedOption.value.gaugeAddress


### PR DESCRIPTION
## Description

update `curve.fi` URL to `curve.finance` after they migrated due to a DNS hack.

## Related Issue



## Motivation and Context

maintain functioning site

## How Has This Been Tested?

not tested

## Screenshots (if appropriate):
